### PR TITLE
Fixes #19 bp issue and updated error format

### DIFF
--- a/actions/algorithm.go
+++ b/actions/algorithm.go
@@ -105,7 +105,7 @@ func AlgorithmHandler(c echo.Context) error {
 	output.Assessments = hs
 	output.Goals = hg
 	output.Referrals = hr
-	output.Errors = make([]string, 0)
+	output.Errors = make([]models.OutputError, 0)
 	output.Errors = append(output.Errors, hrs...)
 	output.Meta.Debug = false
 	output.Meta.CarePlan = false

--- a/contents/guideline_hearts_content.json
+++ b/contents/guideline_hearts_content.json
@@ -367,13 +367,6 @@
                 "message": "Maintain a healthy diet",
                 "refer": "no"
             },
-            "CHOL-CALCULATION-FALSE": {
-                "eval": "No Assessment",
-                "grading": 0,
-                "tfl": "GRAY",
-                "message": "No assessment performed",
-                "refer": "no"
-            },
             "CVD-AGE-FALSE": {
                 "eval": "Not Calculated",
                 "grading": 0,
@@ -443,6 +436,13 @@
                 "tfl": "DARK-RED",
                 "message": "You're at very high CVD risk. Seek immediate care to address risks",
                 "refer": "urgent"
+            },
+            "ASSESSMENT-FALSE": {
+                "eval": "No Assessment",
+                "grading": 0,
+                "tfl": "GRAY",
+                "message": "No assessment performed",
+                "refer": "no"
             }
         },
         "message-pool": [

--- a/models/output.go
+++ b/models/output.go
@@ -6,9 +6,16 @@ import (
 	"github.com/openhealthalgorithms/service/pkg"
 )
 
+// OutputError object
+type OutputError struct {
+	Category string   `json:"category"`
+	Key      string   `json:"key"`
+	Messages []string `json:"messages"`
+}
+
 // Output object
 type Output struct {
-	Errors      []string               `json:"errors"`
+	Errors      []OutputError          `json:"errors"`
 	Meta        Meta                   `json:"meta"`
 	Assessments *ORRAssessments        `json:"assessments"`
 	Goals       []ORRGoal              `json:"goals"`
@@ -25,6 +32,7 @@ func NewOutput(algorithmName string) *Output {
 	output.Meta.APIVersion = pkg.GetVersion()
 	output.Meta.RequestID = uuid.New()
 	output.Meta.Comments = []string{}
+	output.Errors = []OutputError{}
 
 	return output
 }

--- a/pkg/version.go
+++ b/pkg/version.go
@@ -1,6 +1,6 @@
 package pkg
 
-const version = "v1.6.3"
+const version = "v1.6.4"
 
 // GetVersion returns the current version
 func GetVersion() string {


### PR DESCRIPTION
Fixes #19 

**Description**
For the `assessments` that doesn't run the calculations and returns `null`, the format changed to have the following output:

```JSON
"assessment_type": {
      "code": "ASSESSMENT-FALSE",
      "eval": "No Assessment",
      "message": "No assessment performed",
      "refer": "no",
      "target": "",
      "tfl": "GRAY",
      "value": ""
}
```

The `value` and `target` may or may not have any data according to different assessment types.

The generic `error` format is changed from simple `string` to an error object like the following:

```JSON
{
    "category": "assessments",
    "key": "assessment_type",
    "messages": [
        "... error messages ...",
        "... as a list of strings ..."
    ]
}
``` 

**Type**
Bug fix

**Checklist**
- [x] I have read and acknowledged the [Code of conduct](https://github.com/openhealthalgorithms/service/blob/develop/CODE_OF_CONDUCT.md)
- [x] I have read [How to Contribute](https://github.com/openhealthalgorithms/service/blob/develop/CONTRIBUTING.md)
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
- [x] I have built and run the reference app(s) to verify my change fixes the issue and/or does not break the reference app(s)
